### PR TITLE
Fix initial drop speed

### DIFF
--- a/src/hooks/useTetris.ts
+++ b/src/hooks/useTetris.ts
@@ -1,4 +1,5 @@
 import { useState, useEffect, useCallback, useRef } from 'react';
+import { INITIAL_DROP_TIME } from '../constants/tetris';
 import { GameState, Tetromino, TetrominoType } from '../types/tetris';
 import {
   createEmptyBoard,
@@ -24,7 +25,7 @@ const initialGameState: GameState = {
   lines: 0,
   gameOver: false,
   paused: false,
-  dropTime: 1000,
+  dropTime: INITIAL_DROP_TIME,
   lastDrop: 0,
 };
 


### PR DESCRIPTION
## Summary
- use `INITIAL_DROP_TIME` when initializing game state to ensure slow piece drop

## Testing
- `npm run lint` *(fails: ESLint cannot pass due to existing errors)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_684582ec1824832d829a9cb8fb81ff3c