### PR TITLE
Enable selectable start level

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -1,0 +1,1 @@
+language: "ja-JP"

--- a/.cursor/rules/app_overview.mdc
+++ b/.cursor/rules/app_overview.mdc
@@ -1,0 +1,28 @@
+---
+description: 
+globs: 
+alwaysApply: true
+---
+# アプリ概要: TypeScript製テトリスゲーム
+
+## 構成
+- **フロントエンド:** React + TypeScript
+- **主要ディレクトリ:**
+  - `src/components/` : ゲーム画面や操作UIなどのReactコンポーネント群
+  - `src/hooks/` : ゲームロジック用のカスタムフック（例: useTetris）
+  - `src/constants/` : テトリスの定数定義
+  - `src/types/` : 型定義（Tetromino, GameStateなど）
+  - `src/utils/` : テトリスのロジックやユーティリティ関数
+
+## 主な機能
+- テトリスの基本的なプレイ（操作、回転、ホールド、ハードドロップ、スコア・レベル管理）
+- ゲームの一時停止・再開
+- 次のピース・ホールドピースの表示
+- キーボード操作対応
+
+## 技術スタック
+- React, TypeScript, Vite
+
+---
+
+このアプリはTypeScriptとReactで実装されたテトリスゲームです。ゲームロジックはカスタムフック（useTetris）に集約され、UIはコンポーネント分割されています。

--- a/src/components/LevelSelect.tsx
+++ b/src/components/LevelSelect.tsx
@@ -1,0 +1,42 @@
+import React, { useState } from 'react';
+import { MAX_LEVEL } from '../constants/tetris';
+
+interface LevelSelectProps {
+  onStart: (level: number) => void;
+}
+
+export const LevelSelect: React.FC<LevelSelectProps> = ({ onStart }) => {
+  const [level, setLevel] = useState(0);
+
+  const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const value = parseInt(e.target.value, 10);
+    if (!isNaN(value)) {
+      const bounded = Math.min(MAX_LEVEL, Math.max(0, value));
+      setLevel(bounded);
+    }
+  };
+
+  return (
+    <div className="absolute inset-0 bg-black bg-opacity-75 flex items-center justify-center rounded-lg">
+      <div className="bg-gray-800 p-8 rounded-lg border border-gray-600 text-center">
+        <h2 className="text-2xl font-bold text-white mb-4">Select Starting Level</h2>
+        <input
+          type="number"
+          min={0}
+          max={MAX_LEVEL}
+          value={level}
+          onChange={handleChange}
+          className="w-24 text-center mb-4 p-1 bg-gray-700 text-white rounded"
+        />
+        <div>
+          <button
+            onClick={() => onStart(level)}
+            className="px-6 py-2 bg-blue-600 hover:bg-blue-700 text-white rounded-lg font-semibold"
+          >
+            Start
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+};

--- a/src/components/Tetris.tsx
+++ b/src/components/Tetris.tsx
@@ -1,18 +1,29 @@
-import React from 'react';
+import React, { useState } from 'react';
 import { GameBoard } from './GameBoard';
 import { NextPiece } from './NextPiece';
 import { GameStatsComponent } from './GameStats';
 import { GameControls } from './GameControls';
+import { LevelSelect } from './LevelSelect';
 import { useTetris } from '../hooks/useTetris';
 
 export const Tetris: React.FC = () => {
   const { gameState, pieceStats, ghostPiece, actions } = useTetris();
+  const [selectLevel, setSelectLevel] = useState(true);
 
   const gameStats = {
     score: gameState.score,
     level: gameState.level,
     lines: gameState.lines,
     pieces: pieceStats,
+  };
+
+  const startGame = (level: number) => {
+    actions.resetGame(level);
+    setSelectLevel(false);
+  };
+
+  const handleRestart = () => {
+    setSelectLevel(true);
   };
 
   return (
@@ -49,7 +60,7 @@ export const Tetris: React.FC = () => {
                   <p className="text-gray-300 mb-2">Final Score: {gameState.score.toLocaleString()}</p>
                   <p className="text-gray-300 mb-6">Level: {gameState.level}</p>
                   <button
-                    onClick={actions.resetGame}
+                    onClick={handleRestart}
                     className="px-6 py-3 bg-blue-600 hover:bg-blue-700 text-white rounded-lg transition-colors font-semibold"
                   >
                     Play Again
@@ -74,7 +85,7 @@ export const Tetris: React.FC = () => {
             <GameControls
               isPaused={gameState.paused}
               onTogglePause={actions.togglePause}
-              onRestart={actions.resetGame}
+              onRestart={handleRestart}
             />
           </div>
         </div>
@@ -85,6 +96,7 @@ export const Tetris: React.FC = () => {
           </p>
         </footer>
       </div>
+      {selectLevel && <LevelSelect onStart={startGame} />}
     </div>
   );
 };

--- a/src/components/Tetris.tsx
+++ b/src/components/Tetris.tsx
@@ -23,6 +23,7 @@ export const Tetris: React.FC = () => {
   };
 
   const handleRestart = () => {
+    actions.pauseGame();
     setSelectLevel(true);
   };
 

--- a/src/constants/tetris.ts
+++ b/src/constants/tetris.ts
@@ -76,3 +76,5 @@ export const DROP_TIME_BY_LEVEL: Record<number, number> = {
   13: 120,  // 0.12秒
   14: 100,  // 0.1秒（最速）
 };
+
+export const MAX_LEVEL = 14;

--- a/src/hooks/useTetris.ts
+++ b/src/hooks/useTetris.ts
@@ -178,6 +178,7 @@ export const useTetris = () => {
         const newLines = prev.lines + linesCleared;
         const newLevel = calculateLevel(newLines);
         const pointsEarned = calculateScore(linesCleared, prev.level);
+        const newDropTime = calculateDropTime(newLevel);
 
         return {
           ...prev,
@@ -186,7 +187,7 @@ export const useTetris = () => {
           score: prev.score + pointsEarned,
           level: newLevel,
           lines: newLines,
-          // dropTime: 1000,
+          dropTime: newDropTime,
         };
       }
     });
@@ -293,10 +294,12 @@ export const useTetris = () => {
     setGameState(prev => ({ ...prev, paused: !prev.paused }));
   }, []);
 
-  const resetGame = useCallback(() => {
-    setGameState({ 
-      ...initialGameState, 
-      nextPiece: getRandomTetromino() 
+  const resetGame = useCallback((level: number = 0) => {
+    setGameState({
+      ...initialGameState,
+      level,
+      dropTime: calculateDropTime(level),
+      nextPiece: getRandomTetromino()
     });
     setPieceStats({ I: 0, O: 0, T: 0, S: 0, Z: 0, J: 0, L: 0 });
     lastTimeRef.current = 0;

--- a/src/hooks/useTetris.ts
+++ b/src/hooks/useTetris.ts
@@ -23,7 +23,9 @@ const initialGameState: GameState = {
   level: 0,
   lines: 0,
   gameOver: false,
-  paused: false,
+  // Start the game in a paused state so blocks don't fall before the user
+  // selects the starting level.
+  paused: true,
   dropTime: 1000,
   lastDrop: 0,
 };
@@ -294,12 +296,18 @@ export const useTetris = () => {
     setGameState(prev => ({ ...prev, paused: !prev.paused }));
   }, []);
 
+  const pauseGame = useCallback(() => {
+    setGameState(prev => ({ ...prev, paused: true }));
+  }, []);
+
   const resetGame = useCallback((level: number = 0) => {
+    // When starting a new game, unpause so the pieces begin to fall.
     setGameState({
       ...initialGameState,
       level,
+      paused: false,
       dropTime: calculateDropTime(level),
-      nextPiece: getRandomTetromino()
+      nextPiece: getRandomTetromino(),
     });
     setPieceStats({ I: 0, O: 0, T: 0, S: 0, Z: 0, J: 0, L: 0 });
     lastTimeRef.current = 0;
@@ -314,6 +322,7 @@ export const useTetris = () => {
     ghostPiece,
     actions: {
       togglePause,
+      pauseGame,
       resetGame,
       movePiece,
       rotatePiece: rotatePieceAction,


### PR DESCRIPTION
## Summary
- add MAX_LEVEL constant
- calculate drop speed when level changes
- allow starting the game from a chosen level via new LevelSelect component

## Testing
- `npm run lint` *(fails: cannot find package '@eslint/js')*
- `npm run build` *(fails: vite command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684e8a6ee1c0832dbfa74c5c04929503

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - ゲーム開始前および再開時に開始レベルを選択できるレベル選択画面を追加。
  - ゲームは開始時に一時停止状態でスタートするように変更。

- **Improvements**
  - レベルに応じて落下速度が動的に調整されるように改善。
  - ゲームの再開時にレベル選択画面が表示され、プレイの自由度が向上。

- **Documentation**
  - アプリケーションの構成や主要機能を説明する概要ドキュメントを追加。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->